### PR TITLE
Portability tweaks

### DIFF
--- a/dockergui
+++ b/dockergui
@@ -27,6 +27,7 @@ if command -v ratpoison; then
 	sleep 1
 	ratpoison -d :$DNum &
 else # Use the default x window manager installed based on lsb_release id
+
 	DISPLAY=:$DNum
 	distro_id=$(lsb_release -i | awk '{print($3)}')
 
@@ -37,6 +38,10 @@ else # Use the default x window manager installed based on lsb_release id
 			startplasma-x11 &
 		elif [ "${XDG_SESSION_DESKTOP}" == "GNOME" ]; then
 			mutter &
+		else
+			printf "%s\n" "Could not find a suitable Window Manager"
+			exit 1
+
 		fi
  
 	fi
@@ -52,6 +57,9 @@ if command -v docker; then
 	
 elif command -v podman; then 
 	engine_of_choice="podman"
+else
+	printf "%s\n" "Docker/Podman are not installed!"
+	exit 1
 fi
 
 # then run the detected container engine

--- a/dockergui
+++ b/dockergui
@@ -26,7 +26,7 @@ xephyrpid=$!
 if command -v ratpoison; then
 	sleep 1
 	ratpoison -d :$DNum &
-else # Use the default x window manager installed based on the host
+else # Use the default x window manager installed based on lsb_release id
 	DISPLAY=:$DNum
 	distro_id=$(lsb_release -i | awk '{print($3)}')
 
@@ -37,17 +37,39 @@ else # Use the default x window manager installed based on the host
 	fi
 
 fi
+
 windowmanagerpid=$!
 
-docker run --net=host \
-            --rm \
-            -e DISPLAY=:$DNum \
-            -v /tmp/.X11-unix/X$DNum:/tmp/.X11-unix/X$DNum:rw \
-            --user $(id -u):$(id -g) \
-	    --group-add audio \
-	    --cap-drop=ALL \
-	    --shm-size 2g \
-    	    "$@"
+#detect podman or docker
+
+if command -v docker; then
+
+	docker run --net=host \
+		    --rm \
+		    -e DISPLAY=:$DNum \
+		    -v /tmp/.X11-unix/X$DNum:/tmp/.X11-unix/X$DNum:rw \
+		    --user $(id -u):$(id -g) \
+		    --group-add audio \
+		    --cap-drop=ALL \
+		    --shm-size 2g \
+		    "$@"
+
+elif command -v podman; then 
+
+
+	podman run --net=host \
+		    --rm \
+		    -e DISPLAY=:$DNum \
+		    -v /tmp/.X11-unix/X$DNum:/tmp/.X11-unix/X$DNum:rw \
+		    --user $(id -u):$(id -g) \
+		    --group-add audio \
+		    --cap-drop=ALL \
+		    --shm-size 2g \
+		    "$@"
+
+fi
+
+
 kill $windowmanagerpid
 kill $xephyrpid
 

--- a/dockergui
+++ b/dockergui
@@ -26,9 +26,16 @@ xephyrpid=$!
 if command -v ratpoison; then
 	sleep 1
 	ratpoison -d :$DNum &
-else # Use the default x window manager installed
+else # Use the default x window manager installed based on the host
 	DISPLAY=:$DNum
-	x-window-manager &
+	distro_id=$(lsb_release -i | awk '{print($3)}')
+
+	if [ "${distro_id}" == "Ubuntu" ] || [ "${distro_id}" == "Debian" ]; then
+		x-window-manager &
+	else
+		Xorg & #generic case (Fedora, Arch, etc) 
+	fi
+
 fi
 windowmanagerpid=$!
 

--- a/dockergui
+++ b/dockergui
@@ -33,7 +33,12 @@ else # Use the default x window manager installed based on lsb_release id
 	if [ "${distro_id}" == "Ubuntu" ] || [ "${distro_id}" == "Debian" ]; then
 		x-window-manager &
 	else
-		Xorg & #generic case (Fedora, Arch, etc) 
+		if [ "${XDG_SESSION_DESKTOP}" == "KDE" ]; then 
+			startplasma-x11 &
+		elif [ "${XDG_SESSION_DESKTOP}" == "GNOME" ]; then
+			mutter &
+		fi
+ 
 	fi
 
 fi

--- a/dockergui
+++ b/dockergui
@@ -43,32 +43,23 @@ windowmanagerpid=$!
 #detect podman or docker
 
 if command -v docker; then
-
-	docker run --net=host \
-		    --rm \
-		    -e DISPLAY=:$DNum \
-		    -v /tmp/.X11-unix/X$DNum:/tmp/.X11-unix/X$DNum:rw \
-		    --user $(id -u):$(id -g) \
-		    --group-add audio \
-		    --cap-drop=ALL \
-		    --shm-size 2g \
-		    "$@"
-
+	engine_of_choice="docker"
+	
 elif command -v podman; then 
-
-
-	podman run --net=host \
-		    --rm \
-		    -e DISPLAY=:$DNum \
-		    -v /tmp/.X11-unix/X$DNum:/tmp/.X11-unix/X$DNum:rw \
-		    --user $(id -u):$(id -g) \
-		    --group-add audio \
-		    --cap-drop=ALL \
-		    --shm-size 2g \
-		    "$@"
-
+	engine_of_choice="podman"
 fi
 
+# then run the detected container engine
+
+$engine_of_choice run --net=host \
+		    --rm \
+		    -e DISPLAY=:$DNum \
+		    -v /tmp/.X11-unix/X$DNum:/tmp/.X11-unix/X$DNum:rw \
+		    --user $(id -u):$(id -g) \
+		    --group-add audio \
+		    --cap-drop=ALL \
+		    --shm-size 2g \
+		    "$@"
 
 kill $windowmanagerpid
 kill $xephyrpid

--- a/pkg-install
+++ b/pkg-install
@@ -45,4 +45,9 @@ RUN yay -S --noconfirm {package_name}
 ENTRYPOINT [\"/usr/bin/env\", \"{command}\"]"
 """
 
-subprocess.run(["docker", "build", "-t", command, "-"], input = dockerfile, encoding = 'UTF-8')
+try:
+    subprocess.run(["docker", "build", "-t", command, "-"], input = dockerfile, encoding = 'UTF-8')
+
+except FileNotFoundError: # primitive way to detect that docker is not installed
+    subprocess.run(["podman", "build", "-t", command, "-"], input = dockerfile, encoding = 'UTF-8')
+

--- a/pkg-install
+++ b/pkg-install
@@ -3,6 +3,7 @@
 from argparse import ArgumentParser
 from getpass import getuser
 from os import getuid, getgid, getlogin
+from shutil import which
 import subprocess
 
 parser = ArgumentParser(description="Install AUR packages into a Docker container")
@@ -47,13 +48,19 @@ ENTRYPOINT [\"/usr/bin/env\", \"{command}\"]"
 
 # check if either docker or podman are installed
 
-docker_check = subprocess.call(["which", "docker"])
+docker_check = which("docker")
 
-if docker_check != 0:
+podman_check = which("podman")
+
+if docker_check is None:
     print("Docker not installed, building with Podman")
     engine = "podman"
-else:
+elif podman_check is None:
     engine = "docker"
+else:
+    print("Podman/Docker are not installed! Exiting...")
+    exit(1)
+
 
 subprocess.run([engine, "build", "-t", command, "-"], input = dockerfile, encoding = 'UTF-8')
 

--- a/pkg-install
+++ b/pkg-install
@@ -48,19 +48,18 @@ ENTRYPOINT [\"/usr/bin/env\", \"{command}\"]"
 
 # check if either docker or podman are installed
 
-docker_check = which("docker")
+try:
+    if which("docker") is None:
+        print("Docker not installed, building with Podman")
+        engine = "podman"
+    elif which("podman") is None:
+        engine = "docker"
+    else:
+        print("Podman/Docker are not installed! Exiting...")
+        exit(1)
 
-podman_check = which("podman")
 
-if docker_check is None:
-    print("Docker not installed, building with Podman")
-    engine = "podman"
-elif podman_check is None:
-    engine = "docker"
-else:
-    print("Podman/Docker are not installed! Exiting...")
+    subprocess.run([engine, "build", "-t", command, "-"], input = dockerfile, encoding = 'UTF-8')
+except FileNotFoundError:
+    print("An Error has occured while attempting to build the image.")
     exit(1)
-
-
-subprocess.run([engine, "build", "-t", command, "-"], input = dockerfile, encoding = 'UTF-8')
-

--- a/pkg-install
+++ b/pkg-install
@@ -45,9 +45,15 @@ RUN yay -S --noconfirm {package_name}
 ENTRYPOINT [\"/usr/bin/env\", \"{command}\"]"
 """
 
-try:
-    subprocess.run(["docker", "build", "-t", command, "-"], input = dockerfile, encoding = 'UTF-8')
+# check if either docker or podman are installed
 
-except FileNotFoundError: # primitive way to detect that docker is not installed
-    subprocess.run(["podman", "build", "-t", command, "-"], input = dockerfile, encoding = 'UTF-8')
+docker_check = subprocess.call(["which", "docker"])
+
+if docker_check != 0:
+    print("Docker not installed, building with Podman")
+    engine = "podman"
+else:
+    engine = "docker"
+
+subprocess.run([engine, "build", "-t", command, "-"], input = dockerfile, encoding = 'UTF-8')
 


### PR DESCRIPTION
This fork and branch contains two tweaks:

1. I had experienced a issue when the `x-window-manager` command not existing on a Arch box

2. I wanted this to run with `podman` without breaking invocation of `docker` commands. 
Feel free to throw out if this is out of scope.