### PR TITLE
Insert Extra Step before invoking yay

### DIFF
--- a/pkg-install
+++ b/pkg-install
@@ -9,7 +9,7 @@ import subprocess
 parser = ArgumentParser(description="Install AUR packages into a Docker container")
 parser.add_argument("package_name", type=str, help="name of the AUR package")
 parser.add_argument("-x", type=str, metavar='EXECUTABLE', help="name of executable")
-parser.add_argument("-e", type=str, help="add extra step in dockerfile")
+parser.add_argument("-e", type=str, help="edit generic dockerfile")
 args = vars(parser.parse_args())
 
 package_name = args['package_name']
@@ -44,6 +44,7 @@ RUN makepkg -si --noconfirm
 
 #add extra step
 {"RUN " + edit_flag if edit_flag is not None else ""}
+
 
 # Now you can play with whatever package you'd like
 RUN yay -S --noconfirm {package_name}

--- a/pkg-install
+++ b/pkg-install
@@ -9,7 +9,7 @@ import subprocess
 parser = ArgumentParser(description="Install AUR packages into a Docker container")
 parser.add_argument("package_name", type=str, help="name of the AUR package")
 parser.add_argument("-x", type=str, metavar='EXECUTABLE', help="name of executable")
-parser.add_argument("-e", type=str, help="edit generic dockerfile")
+parser.add_argument("-e", type=str, help="add extra step in dockerfile")
 args = vars(parser.parse_args())
 
 package_name = args['package_name']

--- a/pkg-install
+++ b/pkg-install
@@ -9,10 +9,12 @@ import subprocess
 parser = ArgumentParser(description="Install AUR packages into a Docker container")
 parser.add_argument("package_name", type=str, help="name of the AUR package")
 parser.add_argument("-x", type=str, metavar='EXECUTABLE', help="name of executable")
+parser.add_argument("-e", type=str, help="edit generic dockerfile")
 args = vars(parser.parse_args())
 
 package_name = args['package_name']
 command = args['x']
+edit_flag = args['e']
 user = getlogin()
 uid = getuid()
 gid = getgid()
@@ -39,6 +41,14 @@ WORKDIR /home/{user}
 RUN git clone https://aur.archlinux.org/yay.git
 WORKDIR /home/{user}/yay
 RUN makepkg -si --noconfirm
+
+"""
+if edit_flag is not None: #if -e flag is passed then take on the following string
+    extra_run = f"""RUN {edit_flag}"""
+else:
+    extra_run = ""
+
+dockerfile += extra_run + f"""
 
 # Now you can play with whatever package you'd like
 RUN yay -S --noconfirm {package_name}

--- a/pkg-install
+++ b/pkg-install
@@ -9,7 +9,7 @@ import subprocess
 parser = ArgumentParser(description="Install AUR packages into a Docker container")
 parser.add_argument("package_name", type=str, help="name of the AUR package")
 parser.add_argument("-x", type=str, metavar='EXECUTABLE', help="name of executable")
-parser.add_argument("-e", type=str, help="edit generic dockerfile")
+parser.add_argument("-e", type=str, help="add extra step in dockerfile")
 args = vars(parser.parse_args())
 
 package_name = args['package_name']
@@ -42,13 +42,8 @@ RUN git clone https://aur.archlinux.org/yay.git
 WORKDIR /home/{user}/yay
 RUN makepkg -si --noconfirm
 
-"""
-if edit_flag is not None: #if -e flag is passed then take on the following string
-    extra_run = f"""RUN {edit_flag}"""
-else:
-    extra_run = ""
-
-dockerfile += extra_run + f"""
+#add extra step
+{"RUN " + edit_flag if edit_flag is None else ""}
 
 # Now you can play with whatever package you'd like
 RUN yay -S --noconfirm {package_name}

--- a/pkg-install
+++ b/pkg-install
@@ -43,7 +43,7 @@ WORKDIR /home/{user}/yay
 RUN makepkg -si --noconfirm
 
 #add extra step
-{"RUN " + edit_flag if edit_flag is None else ""}
+{"RUN " + edit_flag if edit_flag is not None else ""}
 
 # Now you can play with whatever package you'd like
 RUN yay -S --noconfirm {package_name}


### PR DESCRIPTION
As we know, AUR packages take a while to build... especially when going from zero to hero with the base Arch Docker image that installs `yay` and then uses `yay` to pull down the AUR package.

Now imagine going from Steps 1 - 8 and watching it fail to build because something was not done before downloading your package from the AUR... causing some time to be lost.

Example of such a package: https://aur.archlinux.org/packages/tor-browser

The pinned comment in the link above says that you would have to invoke `gpg --auto-key-locate nodefault,wkd --locate-keys torbrowser@torproject.org` before running `makepkg`. 

Using this commit, you can do such a thing by running `pkg-install tor-browser -e "gpg --auto-key-locate nodefault,wkd --locate-keys torbrowser@torproject.org"` before running `makepkg` and this will be invoked before `yay` is called.